### PR TITLE
Compat version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/jdks.gradle
+++ b/jdks.gradle
@@ -1,25 +1,19 @@
-String compat(String src) {
-   if (src.contains('.')) {
-      src.substring(src.lastIndexOf('.')+1)
-   } else {
-      src
-   }
-}
+def compat = { it.replaceFirst(/^.*\./, '') }
 
 if (project.hasProperty('crossCompile')) {
    // this will configure the java compile tasks with the appropriate JDK
    project.afterEvaluate {
       tasks.withType(JavaCompile) {
-          def version = compat(sourceCompatibility)
-          def jdkHome = System.getenv("JAVA_${version}")
+          def jdkVersion = compat(sourceCompatibility)
+          def jdkHome = System.getenv("JAVA_${jdkVersion}")
           if (!jdkHome) {
-             println "Warning: Please set path to JDK ${version} using environment variable JAVA_${version}"
+             println "Warning: Please set path to JDK ${jdkVersion} using environment variable JAVA_${jdkVersion}"
              println "Falling back to current JDK"
           } else {
              options.fork = true
              options.forkOptions.javaHome = file(jdkHome)
              doFirst {
-                 println "$name compiles using JDK $version"
+                 println "$name compiles using JDK $jdkVersion"
              }
           }
       }
@@ -30,9 +24,9 @@ if (project.hasProperty('crossCompile')) {
    }
    project.afterEvaluate {
       tasks.withType(JavaCompile) {
-         def version = compat(sourceCompatibility)
-         println "Configuring $name to use --release $version"
-         options.compilerArgs.addAll(['--release', version])
+         def jdkVersion = compat(sourceCompatibility)
+         println "Configuring $name to use --release $jdkVersion"
+         options.compilerArgs.addAll(['--release', jdkVersion])
       }
    }
 }


### PR DESCRIPTION
Hi, thanks for the great example on multi-release jars!

This PR targets the following:

* I simplified the compat method. Just let me know if this change is appropriate for your target audience. Some may feel uncomfortable when using a lambda+regex over the good old method+imperative statements.
* Additionally I renamed the variable `version` to `jdkVersion` because a typical Java project might have already defined `version` in a different context (Maven artifact coordinates).